### PR TITLE
move dotenv to config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
+const dotenv = require('dotenv');
 
+dotenv.config();
 
 const config = {
   environment: process.env.NODE_ENV || 'dev',

--- a/index.js
+++ b/index.js
@@ -5,13 +5,11 @@ const helmet     = require('helmet');
 const bodyParser = require('body-parser');
 const morgan     = require('morgan');
 const bluebird   = require('bluebird');
-const dotenv     = require('dotenv');
 const config = require('./config');
 const routes = require('./routes');
 const cors = require('cors');
 
 // TODO: Figure out why process.env.NODE_ENV is undefined at start
-dotenv.config();
 const corsOptions =
 { origin: process.env.AllowUrl,
   credentials: true,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "chai-as-promised": "^6.0.0",
     "chai-http": "^3.0.0",
     "chokidar-cli": "^1.2.0",
-    "dotenv": "^2.0.0",
     "eslint": "^3.2.2",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.12.0",


### PR DESCRIPTION
fix: it wasn't correctly using the PORT variable from env var. 

`PORT` variable is used from `config.server.port` so `dotenv.config()` should be executed there, before it accesses `process.env.PORT`

Also it was listed twice in dependencies and devDependencies. removed from the latter.